### PR TITLE
Added missing dependency to definition-header@0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "basscss-radium": "^3.0.0",
     "chalk": "^1.1.1",
+    "definition-header": "~0.1.0",
     "express": "^4.13.3",
     "history": "^1.17.0",
     "immutable": "^3.7.6",


### PR DESCRIPTION
Without this, `npm run dev` shows error:
```
ERROR in /Users/.../typescript-react-redux-starter/typings/tsd.d.ts
(6,1): error TS6053: File '/
```

Initially tried `definition-header@0.2` but didn't work, looks like `definition-header@0.1` is the intended version?