### PR TITLE
Unshadow __DEV__ global

### DIFF
--- a/src/store/configureStore.tsx
+++ b/src/store/configureStore.tsx
@@ -15,7 +15,7 @@ interface HotNodeModule extends NodeModule {
 };
 
 // This global is used to turn on redux dev tools when in dev mode.
-let __DEV__: string;
+declare let __DEV__: boolean;
 declare let module: HotNodeModule;
 
 const reduxRouterMiddleware = syncHistory(browserHistory);


### PR DESCRIPTION
Ambiently declare the type instead of shadowing the injected global with an uninitialized var.