### PR TITLE
Enforce quote rules with `tslint`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,8 @@ Issues for this particular starter project are tagged with the 'ts-react' label.
 ### Planned work
 
 * Fix/ReOrg BassCSS styles
-* Better support for custom typings (so we don't have to commit typings to the repo)
 * Test examples (unit)
-* Component `displayName`, `propTypes`, `defaultProps` and documentation
-* Auto-reloading API server (when specified)
-* Enforce single-quotes for TS code and double-quotes for JSX.
-  - ref: https://github.com/palantir/tslint/issues/673
+* Component `displayName`, `defaultProps` and documentation
 
 ## If something doesn't work
 

--- a/src/api/mock/users.tsx
+++ b/src/api/mock/users.tsx
@@ -1,14 +1,14 @@
 export default [
   {
-    "Username": "admin",
-    "Password": "superuser"
+    Username: 'admin',
+    Password: 'superuser'
   },
   {
-    "Username": "guest",
-    "Password": "letmein"
+    Username: 'guest',
+    Password: 'letmein'
   },
   {
-    "Username": "user",
-    "Password": "pass"
+    Username: 'user',
+    Password: 'pass'
   }
 ];

--- a/tslint.json
+++ b/tslint.json
@@ -52,6 +52,7 @@
       "check-operator",
       "check-separator",
       "check-type"
-    ]
+    ],
+    "quotemark": [ true, "single", "jsx-double" ]
   }
 }


### PR DESCRIPTION
Double quotes for JSX properties, single quotes for JavaScript strings.

Also updated the 'Planned work' section of the README to reflect recent developments.