### PR TITLE
More idiomatic component syntax

### DIFF
--- a/src/components/alert.tsx
+++ b/src/components/alert.tsx
@@ -14,7 +14,7 @@ const statusClasses = {
   error: 'bg-red white',
 };
 
-function Alert({
+export default function Alert({
   children = null,
   isVisible,
   status = 'info',
@@ -34,5 +34,3 @@ function Alert({
     </div>
   );
 };
-
-export default Alert;

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -8,7 +8,7 @@ interface IButtonProps extends React.Props<any> {
   id?: string;
 };
 
-function Button({
+export default function Button({
   onClick = null,
   type = 'button',
   className = '',
@@ -17,13 +17,13 @@ function Button({
 }: IButtonProps) {
   const buttonClasses = classNames('btn', 'btn-primary', className);
 
-  return <button
-    id={ id }
-    type={ type }
-    className={ buttonClasses }
-    onClick={ onClick }>
-    { children }
-  </button>;
+  return (
+    <button
+      id={ id }
+      type={ type }
+      className={ buttonClasses }
+      onClick={ onClick }>
+      { children }
+    </button>
+  );
 }
-
-export default Button;

--- a/src/components/container.tsx
+++ b/src/components/container.tsx
@@ -6,7 +6,7 @@ interface IContainerProps extends React.Props<any> {
   center: boolean;
 };
 
-function Container({
+export default function Container({
   size = 1,
   center = false,
   children = null
@@ -19,9 +19,9 @@ function Container({
     'mx-auto': center,
   });
 
-  return <div className={ containerClasses }>
-    { children }
-  </div>;
+  return (
+    <div className={ containerClasses }>
+      { children }
+    </div>
+  );
 }
-
-export default Container;

--- a/src/components/content.tsx
+++ b/src/components/content.tsx
@@ -5,10 +5,10 @@ interface IContentProps extends React.Props<any> {
   style?: Object;
 };
 
-function Content({ children = null, isVisible }) {
-  return <main>
-    { isVisible ? children : null }
-  </main>;
+export default function Content({ children = null, isVisible }: IContentProps) {
+  return (
+    <main>
+      { isVisible ? children : null }
+    </main>
+  );
 }
-
-export default Content;

--- a/src/components/counter.tsx
+++ b/src/components/counter.tsx
@@ -7,22 +7,26 @@ interface ICounterProps extends React.Props<any> {
   decrement: () => void;
 };
 
-function Counter({ counter, increment, decrement }) {
-  return <div className="flex">
-    <Button className="bg-black col-2"
-      onClick={ decrement }>
-      -
-    </Button>
+export default function Counter({
+  counter,
+  increment,
+  decrement
+}: ICounterProps) {
+  return (
+    <div className="flex">
+      <Button className="bg-black col-2"
+        onClick={ decrement }>
+        -
+      </Button>
 
-    <div className="flex-auto center h1">
-      { counter }
+      <div className="flex-auto center h1">
+        { counter }
+      </div>
+
+      <Button className="col-2"
+        onClick={ increment }>
+        +
+      </Button>
     </div>
-
-    <Button className="col-2"
-      onClick={ increment }>
-      +
-    </Button>
-  </div>;
+  );
 }
-
-export default Counter;

--- a/src/components/form/form-error.tsx
+++ b/src/components/form/form-error.tsx
@@ -6,16 +6,16 @@ interface IFormErrorProps extends React.Props<any> {
   id?: string;
 };
 
-function FormError({
+export default function FormError({
   children = null,
   isVisible,
   id = ''
 }: IFormErrorProps) {
   const formErrorClasses = classNames('bold', 'black', { 'hide': !isVisible });
 
-  return <div className={ formErrorClasses } id={ id }>
-    { children }
-  </div>;
+  return (
+    <div className={ formErrorClasses } id={ id }>
+      { children }
+    </div>
+  );
 }
-
-export default FormError;

--- a/src/components/form/form-group.tsx
+++ b/src/components/form/form-group.tsx
@@ -2,10 +2,12 @@ import * as React from 'react';
 
 interface IFormGroupProps extends React.Props<any> {};
 
-function FormGroup({ children = null }) {
-  return <div className="py2">
-    { children }
-  </div>;
+export default function FormGroup({
+  children = null
+}: IFormGroupProps) {
+  return (
+    <div className="py2">
+      { children }
+    </div>
+  );
 }
-
-export default FormGroup;

--- a/src/components/form/form-label.tsx
+++ b/src/components/form/form-label.tsx
@@ -4,10 +4,13 @@ interface IFormLabelProps extends React.Props<any> {
   id?: string;
 };
 
-function FormLabel({ children = null, id = '' }) {
-  return <label id={ id }>
-    { children }
-  </label>;
+export default function FormLabel({
+  children = null,
+  id = ''
+}: IFormLabelProps) {
+  return (
+    <label id={ id }>
+      { children }
+    </label>
+  );
 }
-
-export default FormLabel;

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -4,17 +4,17 @@ interface IFormProps extends React.Props<any> {
   handleSubmit: () => void;
 };
 
-function Form({
+export default function Form({
   children = null,
   handleSubmit
 }: IFormProps) {
-  return <form
-    onSubmit={(e) => {
-      e.preventDefault();
-      handleSubmit();
-    }}>
-    { children }
-  </form>;
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleSubmit();
+      }}>
+      { children }
+    </form>
+  );
 }
-
-export default Form;

--- a/src/components/form/input.tsx
+++ b/src/components/form/input.tsx
@@ -8,18 +8,18 @@ interface IInputProps extends React.Props<any> {
   id?: string;
 };
 
-const Input = ({
+export default function Input({
   type = 'text',
   placeholder = '',
   fieldDefinition,
   id = ''
-}) => (
-  <input
-    id={ id }
-    className="block col-12 mb1 input"
-    type={ type }
-    placeholder={ placeholder }
-    { ...fieldDefinition } />
-);
-
-export default Input;
+}) {
+  return (
+    <input
+      id={ id }
+      className="block col-12 mb1 input"
+      type={ type }
+      placeholder={ placeholder }
+      { ...fieldDefinition } />
+  );
+}

--- a/src/components/login/login-form.tsx
+++ b/src/components/login/login-form.tsx
@@ -35,43 +35,45 @@ class LoginForm extends React.Component<ILoginFormProps, void> {
       }
     } = this.props;
 
-    return <Form handleSubmit={ handleSubmit }>
-      <Alert isVisible={ isPending }>Loading...</Alert>
-      <Alert id="qa-alert" isVisible={ hasError } status="error">
-        Invalid username and password
-      </Alert>
+    return (
+      <Form handleSubmit={ handleSubmit }>
+        <Alert isVisible={ isPending }>Loading...</Alert>
+        <Alert id="qa-alert" isVisible={ hasError } status="error">
+          Invalid username and password
+        </Alert>
 
-      <FormGroup>
-        <FormLabel id="qa-uname-label">Username</FormLabel>
-        <Input type="text" fieldDefinition={ username } id="qa-uname-input"/>
-        <FormError id="qa-uname-validation"
-          isVisible={ !!(username.touched && username.error) }>
-          { username.error }
-        </FormError>
-      </FormGroup>
+        <FormGroup>
+          <FormLabel id="qa-uname-label">Username</FormLabel>
+          <Input type="text" fieldDefinition={ username } id="qa-uname-input"/>
+          <FormError id="qa-uname-validation"
+            isVisible={ !!(username.touched && username.error) }>
+            { username.error }
+          </FormError>
+        </FormGroup>
 
-      <FormGroup>
-        <FormLabel id="qa-password-label">Password</FormLabel>
-        <Input type="password"
-          fieldDefinition={ password }
-          id="qa-password-input" />
-        <FormError id="qa-password-validation"
-          isVisible={ !!(password.touched && password.error) }>
-          { password.error }
-        </FormError>
-      </FormGroup>
+        <FormGroup>
+          <FormLabel id="qa-password-label">Password</FormLabel>
+          <Input type="password"
+            fieldDefinition={ password }
+            id="qa-password-input" />
+          <FormError id="qa-password-validation"
+            isVisible={ !!(password.touched && password.error) }>
+            { password.error }
+          </FormError>
+        </FormGroup>
 
-      <FormGroup>
-        <Button type="submit" className="mr1" id="qa-login-button">
-          Login
-        </Button>
-        <Button onClick={ resetForm }
-          type="reset"
-          className="bg-red" id="qa-clear-button">
-          Clear
-        </Button>
-      </FormGroup>
-    </Form>;
+        <FormGroup>
+          <Button type="submit" className="mr1" id="qa-login-button">
+            Login
+          </Button>
+          <Button onClick={ resetForm }
+            type="reset"
+            className="bg-red" id="qa-clear-button">
+            Clear
+          </Button>
+        </FormGroup>
+      </Form>
+    );
   }
 
   static validate(values) {

--- a/src/components/login/login-modal.tsx
+++ b/src/components/login/login-modal.tsx
@@ -9,17 +9,22 @@ interface ILoginModalProps extends React.Props<any> {
   onSubmit: () => void;
 };
 
-function LoginModal({ isVisible, isPending, hasError, onSubmit }) {
-  return <Modal isVisible={ isVisible }>
-    <ModalContent>
-      <h1 className="mt0">Login</h1>
+export default function LoginModal({
+  isVisible,
+  isPending,
+  hasError,
+  onSubmit
+}: ILoginModalProps) {
+  return (
+    <Modal isVisible={ isVisible }>
+      <ModalContent>
+        <h1 className="mt0">Login</h1>
 
-      <LoginForm
-        isPending={ isPending }
-        hasError={ hasError }
-        onSubmit={ onSubmit } />
-    </ModalContent>
-  </Modal>;
+        <LoginForm
+          isPending={ isPending }
+          hasError={ hasError }
+          onSubmit={ onSubmit } />
+      </ModalContent>
+    </Modal>
+  );
 }
-
-export default LoginModal;

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -1,18 +1,14 @@
 import * as React from 'react';
 const LogoImage = require('../assets/rangleio-logo.svg');
 
-interface ILogoProps {
-  style?: Object;
-};
-
-const Logo = () => (
-  <div className="flex items-center">
-    <img style={ styles }
-      src={ LogoImage }
-      alt="Rangle.io" />
-  </div>
-);
-
 const styles = { width: 128 };
 
-export default Logo;
+export default function Logo() {
+  return (
+    <div className="flex items-center">
+      <img style={ styles }
+        src={ LogoImage }
+        alt="Rangle.io" />
+    </div>
+  );
+}

--- a/src/components/modal/modal-content.tsx
+++ b/src/components/modal/modal-content.tsx
@@ -3,16 +3,12 @@ const objectAssign = require('object-assign');
 
 interface IModalContentProps extends React.Props<any> {};
 
-function ModalContent({
+export default function ModalContent({
   children = null
 }: IModalContentProps) {
-  return <div className="p2 z2 bg-white modal relative">
-    <button className="btn absolute top-0 right-0 m1"
-      onClick={ close }>
-      ✖︎
-    </button>
-    { children }
-  </div>;
+  return (
+    <div className="p2 z2 bg-white modal relative">
+      { children }
+    </div>
+  );
 }
-
-export default ModalContent;

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -4,16 +4,19 @@ interface IModalProps extends React.Props<any> {
   isVisible?: boolean;
 };
 
-function Modal({ isVisible = false, children = null }) {
+export default function Modal({
+  isVisible = false,
+  children = null
+}: IModalProps) {
   const styles = {
     visibility: isVisible ? 'visible' : 'hidden',
     opacity: isVisible ? 1 : 0,
   };
 
-  return <div style={ styles }
-    className="fixed top-0 bottom-0 left-0 right-0 z1 bg-darken-3">
-    { children }
-  </div>;
+  return (
+    <div style={ styles }
+      className="fixed top-0 bottom-0 left-0 right-0 z1 bg-darken-3">
+      { children }
+    </div>
+  );
 };
-
-export default Modal;

--- a/src/components/navigator-item.tsx
+++ b/src/components/navigator-item.tsx
@@ -1,27 +1,27 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
 
-interface INavigatorProps extends React.Props<any> {
+interface INavigatorItemProps extends React.Props<any> {
   isVisible?: boolean;
   mr?: boolean;
   ml?: boolean;
 };
 
-const NavigatorItem = ({
+export default function NavigatorItem({
   children = null,
   isVisible = true,
   mr = false,
   ml = false,
-}: INavigatorProps) => {
+}: INavigatorItemProps) {
   const navItemClasses = classNames('truncate', {
     hide: !isVisible,
     mr2: mr,
     ml2: ml,
   });
 
-  return <div className={ navItemClasses }>
-    { children }
-  </div>;
+  return (
+    <div className={ navItemClasses }>
+      { children }
+    </div>
+  );
 };
-
-export default NavigatorItem;

--- a/src/components/navigator.tsx
+++ b/src/components/navigator.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 
 interface INavigatorProps extends React.Props<any> {}
 
-function Navigator({ children = null }) {
-  return <nav className="flex items-center p1 bg-white border-bottom">
-    { children }
-  </nav>;
+export default function Navigator({ children = null }: INavigatorProps) {
+  return (
+    <nav className="flex items-center p1 bg-white border-bottom">
+      { children }
+    </nav>
+  );
 }
-
-export default Navigator;


### PR DESCRIPTION
- `export default function Foo()` instead of exporting on a different line.
- Corrected some places where IFooProps were not being applied to the arguments.
- Added missing parentheses around JSX snippets.
- Converted some arrow-function components to named functions for React DevTools.