### PR TITLE
Avoid an E2E test race condition.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,8 @@ dependencies:
 
 test:
   post:
-    - npm run dev:
+    - npm run build
+    - npm start:
         background: true
     - pybot -d "./e2e/robot/test_results" ./e2e/robot/tests
 


### PR DESCRIPTION
`npm run dev` takes a while to start up; backgrounding it and immediately running the E2E tests leads to sporadic CI failures where the tests start before the webserver is ready.

Instead, do `npm run build` synchronously and then run `npm start` in the background; `npm start` servers the build assets statically and therefore starts up much faster.  It's also how we run things in production and is therefore more appropriate as a test target.