### PR TITLE
Added postcss modules-local-by-default.

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "postcss-cssnext": "^2.4.0",
     "postcss-import": "^8.0.2",
     "postcss-loader": "^0.8.1",
+    "postcss-modules-local-by-default": "^1.0.1",
     "raw-loader": "^0.5.1",
     "react": "^15.0.1",
     "react-dom": "^15.0.1",

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -1,5 +1,4 @@
 import ModalContent from './modal-content';
 import Modal from './modal';
-import './modal.css';
 
 export { ModalContent, Modal };

--- a/src/components/modal/modal-content.tsx
+++ b/src/components/modal/modal-content.tsx
@@ -1,13 +1,18 @@
 import * as React from 'react';
 const objectAssign = require('object-assign');
+import * as classNames from 'classnames';
+const Styles =  require('./modal.css');
 
 interface IModalContentProps extends React.Props<any> {};
 
 export default function ModalContent({
   children = null
 }: IModalContentProps) {
+  const classDef = classNames('p2', 'z2', 'bg-white', 'relative',
+    Styles.modal);
+
   return (
-    <div className="p2 z2 bg-white modal relative">
+    <div className={ classDef }>
       { children }
     </div>
   );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -109,6 +109,7 @@ module.exports = {
 
   postcss: function() {
     return [
+      require('postcss-modules-local-by-default'),
       require('postcss-import')({
         addDependencyTo: webpack
       }),


### PR DESCRIPTION
Updated modal to use classname generated by local scope as an example.

Connected to https://github.com/rangle/rangle-starter/issues/65