### PR TITLE
Updated webpack config to use SplitByPathPlugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "url-loader": "^0.5.6",
     "webpack": "^1.13.0",
     "webpack-dev-server": "^1.14.1",
-    "webpack-hot-middleware": "^2.9.1"
+    "webpack-hot-middleware": "^2.9.1",
+    "webpack-split-by-path": "0.0.8"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const proxy = require('./server/webpack-dev-proxy');
 const loaders = require('./webpack/loaders');
 const styleLintPlugin = require('stylelint-webpack-plugin');
+const SplitByPathPlugin = require('webpack-split-by-path');
 
 const baseAppEntries = [
   './src/index.tsx',
@@ -23,7 +24,9 @@ const basePlugins = [
     __DEV__: process.env.NODE_ENV !== 'production',
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
   }),
-  new webpack.optimize.CommonsChunkPlugin('vendor', '[name].[hash].js'),
+  new SplitByPathPlugin([
+    { name: 'vendor', path: [__dirname + '/node_modules/'] }
+  ]),
   new HtmlWebpackPlugin({
     template: './src/index.html',
     inject: 'body'
@@ -77,18 +80,10 @@ module.exports = {
 
   entry: {
     app: appEntries,
-    vendor: [
+    shims: [
       'es5-shim',
       'es6-shim',
       'es6-promise',
-      'react',
-      'react-dom',
-      'react-redux',
-      'redux',
-      'redux-thunk',
-      'redux-logger',
-      'react-router',
-      'react-router-redux',
     ]
   },
 


### PR DESCRIPTION
Updated the webpack config file to use SplitByPathPlugin for all of the vendor files in node_modules except the shims.

Connected to rangle/rangle-starter#81