### PR TITLE
Import shims directly in index.tsx to make starter consistent with others

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,7 @@
+import 'es5-shim';
+import 'es6-shim';
+import 'es6-promise';
+
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,11 +80,6 @@ module.exports = {
 
   entry: {
     app: appEntries,
-    shims: [
-      'es5-shim',
-      'es6-shim',
-      'es6-promise',
-    ]
   },
 
   output: {


### PR DESCRIPTION
To make this starter consistent with the others. Remove shims from webpack config and explicitly import in index.tsx before React

Tested in Chrome and IE.

Connected to rangle/rangle-starter#100