### PR TITLE
Ensure React render target is valid HTML

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,6 @@
     <title>Rangle.io - Typescript / React / Redux Seed</title>
   </head>
   <body>
-    <div id="root"/>
+    <div id="root"></div>
   </body>
 </html>


### PR DESCRIPTION
So far as I can tell, only void and foreign elements can be self-closing. As is, this simply gets converted into a start tag and could lead to a mismatch in end tags.