### PR TITLE
Fix return type of devToolsExtension global

### DIFF
--- a/src/store/dev-types.d.ts
+++ b/src/store/dev-types.d.ts
@@ -5,7 +5,7 @@ declare let __DEV__: boolean;
 
 // A hack for the Redux DevTools Chrome extension.
 interface Window {
-  devToolsExtension?: () => void;
+  devToolsExtension?: () => Function;
 }
 
 // webpack-hot-loader sets some extra attributes on node's `module`if that


### PR DESCRIPTION
This function should return a store enhancer, as per https://github.com/zalmoxisus/redux-devtools-extension/blob/af027212676c09028f8413052a722f77e55dd590/src/browser/extension/inject/pageScript.js#L187.