### PR TITLE
feat(store/configure-store): Add routerMiddleware

### DIFF
--- a/src/store/configure-store.ts
+++ b/src/store/configure-store.ts
@@ -4,6 +4,8 @@ import { createStore, applyMiddleware, compose } from 'redux';
 import { fromJS } from 'immutable';
 const thunk = require('redux-thunk').default;
 const persistState = require('redux-localstorage');
+const { browserHistory } = require('react-router');
+const { routerMiddleware } = require('react-router-redux');
 
 import promiseMiddleware from '../middleware/promise-middleware';
 import logger from './logger';
@@ -21,6 +23,7 @@ function configureStore(initialState) {
 
 function _getMiddleware() {
   let middleware = [
+    routerMiddleware(browserHistory),
     promiseMiddleware,
     thunk,
   ];


### PR DESCRIPTION
This is exactly the same change in https://github.com/rangle/react-redux-starter/pull/183.

This PR adds the `routerMiddleware` from `react-router-redux`. Now, the following will change the browser's route (before it didn't):

```JavaScript
import { push } from 'react-router-redux';

store.dispatch(push('/top'));
```