### PR TITLE
Values undefined on page load causing error

### DIFF
--- a/src/components/login/login-form.tsx
+++ b/src/components/login/login-form.tsx
@@ -77,7 +77,7 @@ class LoginForm extends React.Component<ILoginFormProps, void> {
     );
   }
 
-  static validate(values) {
+  static validate(values : any = {}) {
     const errors = { username: '', password: '' };
 
     if (!values.username) {


### PR DESCRIPTION
This causes an error when username/password attempt to be accessed. To resolve, I've defaulted the param to an empty object.